### PR TITLE
Add udev rules for seeed device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,5 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ The Ninja Lantern is an interactive Turkish lamp that changes colors in response
 - RGB LED(Neopixel)
 - Appropriate wiring
 
+### Optional Hardware
+
+- Seeed USB Serial(Seeed Studio XIAO ESP32C3)
+
 ## Setup
 
 1. Gather the necessary hardware and connect it to the Raspberry Pi.
@@ -82,9 +86,40 @@ Multi process version and full screen
 $ sudo python3 ninja_lantern_mp.py --use_fullscreen True
 ```
 
+### Optional Setup
+
+If you use Seeed USB Serial(Seeed Studio XIAO ESP32C3), execute following 
+
+```sh
+$ sudo cp config/99-seeed-serial.rules /etc/udev/rules.d/
+$ sudo udevadm control --reload
+```
+
 ## Usage
 
+Run the script to start the Ninja Lantern.
+
+Single process version
+
+```bash
+$ sudo python3 ninja_lantern.py
+```
+
+Multi process version and full screen
+
+```bash
+$ sudo python3 ninja_lantern_mp.py --use_fullscreen True
+```
+
 Simply bring your hand seal in front of the camera and enjoy as the lamp changes color accordingly.
+
+### Optional Usage
+
+If you use Seeed USB Serial(Seeed Studio XIAO ESP32C3), execute following 
+
+```bash
+$ python3 ninja_lantern_ed.py --use_fullscreen True
+```
 
 ## Contributions
 

--- a/config/99-seeed-serial.rules
+++ b/config/99-seeed-serial.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="tty", ATTRS{idVendor}=="303a", ATTRS{idProduct}=="1001", SYMLINK+="seeedusbserial", MODE="0666"

--- a/ninja_lantern_ed.py
+++ b/ninja_lantern_ed.py
@@ -18,7 +18,7 @@ import serial
 
 
 # LED strip configuration:
-LED_PORT = '/dev/ttyACM2'
+LED_PORT = '/dev/seeedusbserial'
 LED_COUNT = 10          # Number of LED pixels.
 
 


### PR DESCRIPTION
## Purpose

Add udev rules for seeed device

## Effect

No need to worry about the order in which USB devices are plugged in

## Test

Execute `python3 ninja_lantern_ed.py`

## Test Environment

### Hardware

Ninja Lantern with seeed device

### Software(Library)


## Memo
